### PR TITLE
feat: Improve mobile responsiveness for key components

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { ArrowDownIcon } from "lucide-react";
 import Link from "next/link";
 import GitHubCalendar from "react-github-calendar";
+import useResponsiveValue from "@/lib/hooks/useResponsiveValue";
 
 export default function Hero() {
   return (
@@ -36,10 +37,10 @@ export default function Hero() {
 
             <GitHubCalendar
               colorScheme="light"
-              blockSize={15}
+              blockSize={useResponsiveValue({ base: 10, md: 12, lg: 15 }, 10)}
               blockMargin={3}
               username="appsicle"
-              fontSize={15}
+              fontSize={useResponsiveValue({ base: 10, md: 12, lg: 15 }, 10)}
               year={2025}
               showWeekdayLabels={true}
             />

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -92,7 +92,7 @@ function ProjectCard({ project, index }: { project: Project; index: number }) {
                 alt={project.title}
                 width={600}
                 height={400}
-                className="w-full h-56 object-cover"
+                className="w-full h-40 sm:h-48 md:h-56 object-cover"
               />
             </div>
           </CardHeader>

--- a/lib/hooks/useResponsiveValue.ts
+++ b/lib/hooks/useResponsiveValue.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+
+type Breakpoints = 'base' | 'sm' | 'md' | 'lg' | 'xl';
+
+function useResponsiveValue<T>(values: Partial<Record<Breakpoints, T>>, defaultValue?: T): T | undefined {
+  const [value, setValue] = useState<T | undefined>(defaultValue);
+
+  useEffect(() => {
+    const calculateValue = () => {
+      const screenWidth = window.innerWidth;
+      let newValue: T | undefined = values.base ?? defaultValue;
+
+      if (screenWidth >= 640 && values.sm !== undefined) {
+        newValue = values.sm;
+      }
+      if (screenWidth >= 768 && values.md !== undefined) {
+        newValue = values.md;
+      }
+      if (screenWidth >= 1024 && values.lg !== undefined) {
+        newValue = values.lg;
+      }
+      if (screenWidth >= 1280 && values.xl !== undefined) {
+        newValue = values.xl;
+      }
+      setValue(newValue);
+    };
+
+    calculateValue();
+    window.addEventListener('resize', calculateValue);
+    return () => window.removeEventListener('resize', calculateValue);
+  }, [values, defaultValue]);
+
+  return value;
+}
+
+export default useResponsiveValue;


### PR DESCRIPTION
This commit introduces several optimizations to enhance the site's usability on mobile devices:

1.  **Hero Section - GitHubCalendar:**
    - Implemented a new `useResponsiveValue` hook (`lib/hooks/useResponsiveValue.ts`) to dynamically adjust props based on screen breakpoints.
    - The `GitHubCalendar` component in `Hero.tsx` now uses this hook to change `blockSize` and `fontSize`.
        - Mobile (<768px): `blockSize` & `fontSize` = 10
        - Tablet (768px-1023px): `blockSize` & `fontSize` = 12 - Desktop (>=1024px): `blockSize` & `fontSize` = 15 (original size)
    - This ensures the calendar is legible and fits well on smaller screens.

2.  **Projects Section - Card Image Height:**
    - Modified the project card images in `Projects.tsx` to use responsive heights.
    - Tailwind classes changed from a fixed `h-56` to `h-40 sm:h-48 md:h-56`.
        - Mobile (<640px): Image height is 10rem (160px).
        - Small screens (640px-768px): Image height is 12rem (192px). - Medium screens and up (>=768px): Image height is 14rem (224px) (original size).
    - This prevents images from taking up excessive vertical space on mobile devices.

These changes contribute to a better user experience across various screen sizes, particularly for mobile users.